### PR TITLE
Add database container dependency

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     command: ["daemon"]
     environment:
     - DATABASE_URL=postgres://postgres:postgres@db/what-the-src
+    depends_on:
+      - db
 
   worker:
     build: .
@@ -15,6 +17,8 @@ services:
     command: ["worker"]
     environment:
     - DATABASE_URL=postgres://postgres:postgres@db/what-the-src
+    depends_on:
+      - db
 
   db:
     image: postgres:16-alpine


### PR DESCRIPTION
Avoid the daemon/worker containers failing because of the database one not being ready yet.