### PR TITLE
Try using melange and apko to build the binary and image with proper caching

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,20 +17,43 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Install melange
+      run: |
+        wget -O melange.tgz 'https://github.com/chainguard-dev/melange/releases/download/v0.7.0/melange_0.7.0_linux_amd64.tar.gz'
+        echo '00523c7ce0dba3ce77f50c2f6693059c0950ddd815aec8c565a014108301d957  melange.tgz' | sha256sum -c -
+        tar -xvzf melange.tgz --strip-components=1 --wildcards '*/melange'
+        sudo install -m755 melange -t /usr/bin
+
+    - name: Install apko
+      run: |
+        wget -O apko.tgz 'https://github.com/chainguard-dev/apko/releases/download/v0.14.1/apko_0.14.1_linux_amd64.tar.gz'
+        echo 'fd44853e845bc47d345b35840c76d1a0ef878e169ff8f9af48b595caa91456ce  apko.tgz' | sha256sum -c -
+        tar -xvzf apko.tgz --strip-components=1 --wildcards '*/apko'
+        sudo install -m755 apko -t /usr/bin
+
     - name: Set up cargo cache
       uses: actions/cache@v4
       with:
         path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-cargo-debug-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: ${{ runner.os }}-cargo-debug-
+          melange-cache
+        key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: ${{ runner.os }}-cargo-release-
 
-    - name: Build
-      run: cargo build --locked --verbose
+    - name: Setup
+      run: |
+        mkdir -p melange-cache/
+        melange keygen melange.rsa --key-size 2048
+
+    - name: Build package
+      run: |
+        TMPDIR=/var/tmp melange build --signing-key melange.rsa --runner docker
+        sudo find melange-cache -type f -exec chmod chmod og+r {} \+
+
+    #- name: Build image
+    #  run: |
+    #    apko build apko.yaml what-the-src:edge container.tar
+    #    tar tvvf container.tar
+
   unit-test:
     runs-on: ubuntu-24.04
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+/melange-cache
+/melange.rsa*
+/packages
 /target

--- a/apko.yaml
+++ b/apko.yaml
@@ -1,0 +1,15 @@
+archs:
+  - amd64
+
+contents:
+  keyring:
+    - melange.rsa.pub
+  repositories:
+    - https://dl-cdn.alpinelinux.org/alpine/edge/main
+    - "@local packages"
+  packages:
+    - alpine-base
+    - "what-the-src@local"
+
+entrypoint:
+  command: what-the-src

--- a/melange.yaml
+++ b/melange.yaml
@@ -1,0 +1,39 @@
+package:
+  name: what-the-src
+  version: 0.1.0
+  description: "backend binary"
+  copyright:
+    - license: GPL-3.0-or-later
+  target-architecture:
+    - x86_64
+  dependencies:
+    runtime:
+      - git
+
+environment:
+  contents:
+    repositories:
+      - https://dl-cdn.alpinelinux.org/alpine/edge/main
+      - https://dl-cdn.alpinelinux.org/alpine/edge/community
+    packages:
+      - alpine-baselayout-data
+      - busybox
+      - bzip2-dev
+      - ca-certificates-bundle
+      - cargo
+      - clang
+      - coreutils
+      - mold
+      - postgresql-dev
+      - xz-dev
+      - zstd-dev
+  environment:
+    CARGO_HOME: /var/cache/melange/cargo
+    CARGO_TARGET_DIR: /var/cache/melange/target
+    RUSTFLAGS: "-C linker=clang -C link-arg=-fuse-ld=/usr/bin/mold"
+
+pipeline:
+  - runs: mkdir db
+  - runs: ln -s ../migrations db
+  - runs: cargo build --release --locked --verbose
+  - runs: install -Dm755 "$CARGO_TARGET_DIR/release/what-the-src" -t "${{targets.contextdir}}/usr/bin"


### PR DESCRIPTION
Building the container image currently takes about 6-7min:

![image](https://github.com/kpcyrd/what-the-src/assets/7763184/6ea670a3-0f52-45b2-9498-0b0722af5259)

Trying to compete with #25.